### PR TITLE
Fix layout on older WebOS

### DIFF
--- a/org.jellyfin.webos/appinfo.json
+++ b/org.jellyfin.webos/appinfo.json
@@ -5,7 +5,7 @@
     "bgImage": "assets/splash.png",
     "title": "Jellyfin",
     "type": "web",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "splashBackground": "assets/splash.png",
     "bgColor": "#000b25",
     "vendor": "Jellyfin Project",

--- a/org.jellyfin.webos/css/main.css
+++ b/org.jellyfin.webos/css/main.css
@@ -15,6 +15,9 @@ body {
     text-align: center;
     color: #FFFFFF;
     display: flex;
+    display: -webkit-box;
+    -webkit-box-pack: center;
+    -webkit-box-orient: vertical;
     flex-direction: column;
     flex-wrap: flex-direction;
     justify-content: center;
@@ -28,11 +31,11 @@ body {
 }
 
 #logo {
-    width: 60%;
+    max-width: 100%;
 }
 
 #logo img {
-    width: 60%;
+    width: 40%;
 }
 
 input,

--- a/org.jellyfin.webos/index.html
+++ b/org.jellyfin.webos/index.html
@@ -19,7 +19,7 @@
 		<div id="serverInfoForm">
 			<p id="error" style="display: none;">&nbsp;</p>
 			<form onsubmit="return false;">
-				<input type="url" id="baseurl" name="baseurl" placeholder="https://jellyfin.local:8096" tabindex="0" /><br>
+				<input type="url" id="baseurl" name="baseurl" placeholder="http://jellyfin.local:8096" tabindex="0" /><br>
 				<input type="checkbox" id="auto_connect" name="auto_connect"
 					onclick="return handleCheckbox(this, true);" onkeydown="return handleCheckbox(this, event);"
 					tabindex="1" value="1" />

--- a/org.jellyfin.webos/index.html
+++ b/org.jellyfin.webos/index.html
@@ -19,7 +19,7 @@
 		<div id="serverInfoForm">
 			<p id="error" style="display: none;">&nbsp;</p>
 			<form onsubmit="return false;">
-				<input type="url" id="baseurl" name="baseurl" placeholder="https://jellfin.local:8096" tabindex="0" /><br>
+				<input type="url" id="baseurl" name="baseurl" placeholder="https://jellyfin.local:8096" tabindex="0" /><br>
 				<input type="checkbox" id="auto_connect" name="auto_connect"
 					onclick="return handleCheckbox(this, true);" onkeydown="return handleCheckbox(this, event);"
 					tabindex="1" value="1" />

--- a/org.jellyfin.webos/js/index.js
+++ b/org.jellyfin.webos/js/index.js
@@ -89,7 +89,7 @@ document.onkeydown = function (evt) {
 function handleCheckbox(elem, evt) {
     console.log(elem);
     if (evt === true) {
-        elem.checked = !elem.checked; //click event
+        return true; // webos should be capable of toggling the checkbox by itself
     } else {
         evt = evt || window.event; //keydown event
         if (evt.keyCode == 13 || evt.keyCode == 32) { //OK button or Space
@@ -253,6 +253,7 @@ function handleFailure(data) {
 
     hideConnecting();
     storage.remove('connected_server');
+    curr_req = false;
 }
 
 function abort() {


### PR DESCRIPTION
Also fix a few minor issues:
* Clicking on a checkbox with a mouse caused it to toggle twice, at least on WebOS 2.0 emulator, so I just decided to rely on native browser feature for toggling the checkbox
* Fix placeholder text
* Make non-first request display "Connecting..." label correctly if previous request failed for any reason

Tested that all stuff displays, checks/unchecks and tries to connect on 1.2, 2.0, 3.0 and 4.0 emulators.
Didn't try to connect to a real JF server, though.

Layout issue in WebOS 2.0 (before fix):
![jf2](https://user-images.githubusercontent.com/1011526/72544049-b9fffd00-3897-11ea-8bd6-4d5f6a363600.png)

Now layout looks like this in WebOS 2.0:
![jf3](https://user-images.githubusercontent.com/1011526/72544281-1d8a2a80-3898-11ea-8190-80cf66971611.png)
