### PR TITLE
Open Jellyfin in iframe to fix scrolling in webOS 3

### DIFF
--- a/org.jellyfin.webos/appinfo.json
+++ b/org.jellyfin.webos/appinfo.json
@@ -11,5 +11,6 @@
     "vendor": "Jellyfin Project",
     "largeIcon": "assets/icon-transparent130.png",
     "iconColor": "#000b25",
-    "id": "org.jellyfin.webos"
+    "id": "org.jellyfin.webos",
+    "disableBackHistoryAPI": true
 }

--- a/org.jellyfin.webos/css/main.css
+++ b/org.jellyfin.webos/css/main.css
@@ -1,10 +1,22 @@
+html,
+body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
 body {
     width: 100%;
-    height: 100%;
     font-size: 36px;
     font-family: -apple-system, "Helvetica", system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", "Open Sans", sans-serif;
     background-color: #000b25;
     color: white;
+}
+
+#contentFrame {
+    border: none;
+    width: 100%;
+    height: 100%;
 }
 
 .container {

--- a/org.jellyfin.webos/css/webOS.css
+++ b/org.jellyfin.webos/css/webOS.css
@@ -1,0 +1,3 @@
+.layout-tv body::-webkit-scrollbar {
+    display: none;
+}

--- a/org.jellyfin.webos/index.html
+++ b/org.jellyfin.webos/index.html
@@ -32,6 +32,7 @@
 			<button id="abort" onclick="abort();">Abort</button>
 		</div>
 	</div>
+	<iframe id="contentFrame" style="display: none;"></iframe>
 </body>
 
 </html>

--- a/org.jellyfin.webos/js/index.js
+++ b/org.jellyfin.webos/js/index.js
@@ -68,6 +68,10 @@ function rightArrowPressed() {
     // Your stuff here
 }
 
+function backPressed() {
+    webOS.platformBack();
+}
+
 document.onkeydown = function (evt) {
     evt = evt || window.event;
     switch (evt.keyCode) {
@@ -82,6 +86,9 @@ document.onkeydown = function (evt) {
             break;
         case 40:
             downArrowPressed();
+            break;
+        case 461: // Back
+            backPressed();
             break;
     }
 };
@@ -268,5 +275,15 @@ function abort() {
 function handoff(url) {
     console.log("Handoff called with: ", url)
     //hideConnecting();
-    location.href = url;
+
+    document.querySelector('.container').style.display = 'none';
+
+    var contentFrame = document.querySelector('#contentFrame');
+
+    contentFrame.onload = function () {
+        contentFrame.contentWindow.webOS = webOS;
+    };
+
+    contentFrame.style.display = '';
+    contentFrame.src = url;
 }

--- a/org.jellyfin.webos/js/webOS.js
+++ b/org.jellyfin.webos/js/webOS.js
@@ -1,0 +1,18 @@
+(function() {
+    'use strict';
+
+    console.log('WebOS adapter');
+
+    function postMessage(type, data) {
+        window.top.postMessage({
+            type: type,
+            data: data
+        }, '*');
+    }
+
+    window.webOS = {
+        platformBack: function () {
+            postMessage('AppHost.exit');
+        }
+    };
+})();

--- a/org.jellyfin.webos/js/webOS.js
+++ b/org.jellyfin.webos/js/webOS.js
@@ -1,4 +1,4 @@
-(function() {
+(function(AppInfo) {
     'use strict';
 
     console.log('WebOS adapter');
@@ -10,9 +10,114 @@
         }, '*');
     }
 
-    window.webOS = {
-        platformBack: function () {
-            postMessage('AppHost.exit');
+    // List of supported features
+    var SupportedFeatures = [
+        'exit',
+        'externallinkdisplay',
+        'htmlaudioautoplay',
+        'htmlvideoautoplay',
+        'imageanalysis',
+        'physicalvolumecontrol',
+        'displaylanguage',
+        'otherapppromotions',
+        'targetblank',
+        'screensaver',
+        'subtitleappearancesettings',
+        'subtitleburnsettings',
+        'chromecast',
+        'multiserver'
+    ];
+
+    window.NativeShell = {
+        AppHost: {
+            init: function () {
+                postMessage('AppHost.init', AppInfo);
+                return Promise.resolve(AppInfo);
+            },
+
+            appName: function () {
+                postMessage('AppHost.appName', AppInfo.appName);
+                return AppInfo.appName;
+            },
+
+            appVersion: function () {
+                postMessage('AppHost.appVersion', AppInfo.appVersion);
+                return AppInfo.appVersion;
+            },
+
+            deviceId: function () {
+                postMessage('AppHost.deviceId', AppInfo.deviceId);
+                return AppInfo.deviceId;
+            },
+
+            deviceName: function () {
+                postMessage('AppHost.deviceName', AppInfo.deviceName);
+                return AppInfo.deviceName;
+            },
+
+            exit: function () {
+                postMessage('AppHost.exit');
+            },
+
+            getDefaultLayout: function () {
+                postMessage('AppHost.getDefaultLayout', 'tv');
+                return 'tv';
+            },
+
+            getDeviceProfile: function (profileBuilder) {
+                postMessage('AppHost.getDeviceProfile');
+                return profileBuilder({ enableMkvProgressive: false });
+            },
+
+            getSyncProfile: function (profileBuilder) {
+                postMessage('AppHost.getSyncProfile');
+                return profileBuilder({ enableMkvProgressive: false });
+            },
+
+            supports: function (command) {
+                var isSupported = command && SupportedFeatures.indexOf(command.toLowerCase()) != -1;
+                postMessage('AppHost.supports', {
+                    command: command,
+                    isSupported: isSupported
+                });
+                return isSupported;
+            }
+        },
+
+        selectServer: function () {
+            postMessage('selectServer');
+        },
+
+        downloadFile: function (url) {
+            postMessage('downloadFile', { url: url });
+        },
+
+        enableFullscreen: function () {
+            postMessage('enableFullscreen');
+        },
+
+        disableFullscreen: function () {
+            postMessage('disableFullscreen');
+        },
+
+        getPlugins: function () {
+            postMessage('getPlugins');
+            return [];
+        },
+
+        openUrl: function (url, target) {
+            postMessage('openUrl', {
+                url: url,
+                target: target
+            });
+        },
+
+        updateMediaSession: function (mediaInfo) {
+            postMessage('updateMediaSession', { mediaInfo: mediaInfo });
+        },
+
+        hideMediaSession: function () {
+            postMessage('hideMediaSession');
         }
     };
-})();
+})(window.AppInfo);


### PR DESCRIPTION
**This PR requires "Go back" handling in `jellyfin-web` and have no backward compatibility.**
_Perhaps backward compatibility can be added by checking the version less than 10.5.0 and performing `history.back` on frame `contentWindow`._

Opening Jellyfin in iframe fixes scrolling issue in webOS 3. But then handling of "Back" button in iframe is broken. So, we have to handle it manually (_almost finished_).

Also, in this PR I pass ~`webOS`~`NativeShell` object into `jellyfin-web` to be able to "exit" in platform-specific way.

Inject CSS to hide scrollbar.

~**Some flaws**~
~A vertical scrollbar appears. Adding `scrolling="no"` to iframe makes it unscrollable by wheel (but scrollable by ScrollManager). A possible solution (if scrollbar should be hidden) is to add in `jellyfin-web` something like:~
```css
.layout-tv body::-webkit-scrollbar {
    display: none;
}
```
~But non-app TV-layout users will be affected too.~

~**Important note**
After loading JF (in the frame), you cannot return to the server form (for example, to change server) without restarting the application.~