### PR TITLE
Hand-rolling promises as they are broken in WebOS <= 2.0

### DIFF
--- a/org.jellyfin.webos/appinfo.json
+++ b/org.jellyfin.webos/appinfo.json
@@ -5,7 +5,7 @@
     "bgImage": "assets/splash.png",
     "title": "Jellyfin",
     "type": "web",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "splashBackground": "assets/splash.png",
     "bgColor": "#000b25",
     "vendor": "Jellyfin Project",

--- a/org.jellyfin.webos/js/index.js
+++ b/org.jellyfin.webos/js/index.js
@@ -173,6 +173,7 @@ function validURL(str) {
 }
 
 function normalizeUrl(url) {
+    url = url.trimLeft ? url.trimLeft() : url.trimStart();
     if (url.indexOf("http://") != 0 && url.indexOf("https://") != 0) {
         // assume http
         url = "http://" + url;

--- a/org.jellyfin.webos/js/webOS.js
+++ b/org.jellyfin.webos/js/webOS.js
@@ -66,7 +66,7 @@
 
             getDeviceProfile: function (profileBuilder) {
                 postMessage('AppHost.getDeviceProfile');
-                return profileBuilder({ enableMkvProgressive: false });
+                return profileBuilder({ enableMkvProgressive: false, enableSsaRender: true });
             },
 
             getSyncProfile: function (profileBuilder) {


### PR DESCRIPTION
* WebOS 1.x doesn't have `Promise` at all
* WebOS 2.0 `Promise` is bugged

Given the code is really minimal I decided to hand-roll callbacks instead.

Also I have added a bit of URL normalization and added a few missing semicolons.