### PR TITLE
Fix layout for v1 and v2 webos #44

### DIFF
--- a/org.jellyfin.webos/css/main.css
+++ b/org.jellyfin.webos/css/main.css
@@ -37,15 +37,18 @@ body {
     width: 100%;
     vertical-align: middle;
     color: #FFF;
-    display: -webkit-box;
-    display: flex;
-    -webkit-box-pack: center;
-    -webkit-box-orient: vertical;
-    flex-direction: column;
-    flex-wrap: flex-direction;
-    justify-content: center;
-    align-items: center;
-    align-content: center;
+    display:-webkit-flex;
+    display:flex;
+    -webkit-flex-direction: column;
+            flex-direction: column;
+    -webkit-flex-wrap: flex-direction;
+            flex-wrap: flex-direction;
+    -webkit-justify-content: center;
+            justify-content: center;
+    -webkit-align-items: center;
+            align-items: center;
+    -webkit-align-content: center;
+            align-content: center;
 }
 
 .container > div {


### PR DESCRIPTION
Fix for misaligned layout on webos v1 and v2

Before:
![before](https://user-images.githubusercontent.com/46535877/115115553-d197cb00-9f9d-11eb-8a86-646caa15f97c.png)

After:
![after](https://user-images.githubusercontent.com/46535877/115115563-dceaf680-9f9d-11eb-8be8-604284ab44ff.png)
