### PR TITLE
Add CI packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           args: >-
             ares-package
             --no-minify
-            --output build/
+            --outdir build/
             org.jellyfin.webos
 
       - name: Upload GitHub Release Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  push:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - id: var
+        name: Prepare environment
+        run: |
+          rm -rf ./build/*
+          mkdir ./build
+
+      - name: Check packaging
+        uses: docker://ghcr.io/oddstr13/docker-tizen-webos-sdk:webos-only
+        with:
+          args: >-
+            ares-package
+            --check
+            org.jellyfin.webos
+
+      - name: Build package
+        uses: docker://ghcr.io/oddstr13/docker-tizen-webos-sdk:webos-only
+        with:
+          args: >-
+            ares-package
+            --no-minify
+            --output build/
+            org.jellyfin.webos
+
+      - name: Upload GitHub Release Artifacts
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: 'build/*'
+          overwrite: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - id: var
-        name: Prepare environment
+      - name: Prepare environment
         run: |
           rm -rf ./build/*
           mkdir ./build

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ local.properties
 OutputIPK/
 Thumbs.db
 *.ipk
+
+# Artifacts from setting Docker WORKDIR the same as HOME
+.ssh/
+.webos/
+.bash_history

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
  - [Narfinger](https://github.com/Narfinger)
  - [JustAMan](https://github.com/JustAMan)
  - [dkanada](https://github.com/dkanada)
+ - [Oddstr13](https://github.com/oddstr13)
 
 # PlayZ Contributors
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fill in your hostname, port and schema and click connect. The app will check for
 And then the app hands off control to the hosted webUI.
 
 # Developement
-Building the app with the webOS SDK can be done either via Docker or by [installing the webOS SDK](https://webostv.developer.lge.com/sdk/installation/download-installer/) directly.
+Building the app with the webOS SDK can be done either [via Docker](https://ghcr.io/oddstr13/docker-tizen-webos-sdk) or by [installing the webOS SDK](https://webostv.developer.lge.com/sdk/installation/download-installer/) directly.
 `dev.sh` is a wrapper around the Docker commands, if you have installed the SDK directly, just ommit that part.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -13,3 +13,41 @@ All Jellyfin webOS code is licensed under the MPL 2.0 license, some parts incorp
 # Usage
 Fill in your hostname, port and schema and click connect. The app will check for a server by grabbing the manifest and the public serverinfo.
 And then the app hands off control to the hosted webUI.
+
+# Developement
+Building the app with the webOS SDK can be done either via Docker or by [installing the webOS SDK](https://webostv.developer.lge.com/sdk/installation/download-installer/) directly.
+`dev.sh` is a wrapper around the Docker commands, if you have installed the SDK directly, just ommit that part.
+
+## Building
+Building is easy, and doesn't require anything besides the SDK:
+
+```sh
+# Build the package
+./dev.sh ares-build --no-minify org.jellyfin.webos
+```
+
+## Testing
+Testing on a TV requires [registering a LG Developer](https://webostv.developer.lge.com/develop/app-test/preparing-account/), and [setting up the devmode app](https://webostv.developer.lge.com/develop/app-test/using-devmode-app/)
+
+Once you have installed the devmode app on your target TV and logged in with your LG developer account, you need to turn on the `Dev Mode Status` and `Key Server`.
+Take a note of the Passphrase.
+
+```sh
+# Add your TV. The defaults are fine, but I recommend naming it `tv`.
+./dev.sh ares-setup-device --search
+
+# This command sets up the SSH key for the device `tv` (Key Server must be running)
+./dev.sh ares-novacom --device tv --getkey
+
+# Run this command to verify that things are working.
+./dev.sh ares-device-info -d tv
+
+# This command installs the app. Remember to build it first.
+./dev.sh ares-install -d tv org.jellyfin.webos_*.ipk
+
+# Launch the app and the web developer console.
+./dev.sh ares-inspect -d tv org.jellyfin.webos
+
+# Or just launch the app.
+./dev.sh ares-launch -d tv org.jellyfin.webos
+```

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Building is easy, and doesn't require anything besides the SDK:
 ```
 
 ## Testing
-Testing on a TV requires [registering a LG Developer](https://webostv.developer.lge.com/develop/app-test/preparing-account/), and [setting up the devmode app](https://webostv.developer.lge.com/develop/app-test/using-devmode-app/)
+Testing on a TV requires [registering a LG developer account](https://webostv.developer.lge.com/develop/app-test/preparing-account/) and [setting up the devmode app](https://webostv.developer.lge.com/develop/app-test/using-devmode-app/).
 
 Once you have installed the devmode app on your target TV and logged in with your LG developer account, you need to turn on the `Dev Mode Status` and `Key Server`.
-Take a note of the Passphrase.
+**Make sure** to take a note of the passphrase.
 
 ```sh
 # Add your TV. The defaults are fine, but I recommend naming it `tv`.

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+CONTAINER_IMAGE="ghcr.io/oddstr13/docker-tizen-webos-sdk:webos-only"
+
+MY=$(realpath "$(dirname $0)")
+
+function ct {
+  docker container run -it --rm --user=$UID --network=host -v "${MY}":/home/developer $CONTAINER_IMAGE "$@"
+}
+
+if [ $# -lt 1 ]; then
+  echo "Available commands:"
+  echo "bash               Enter container command line"
+  ct ares --list
+else
+  ct "$@"
+fi

--- a/org.jellyfin.webos/package.json
+++ b/org.jellyfin.webos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.jellyfin.webos.service",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Jellyfin Discovery Service",
   "main": "jellyfin_service.js",
   "scripts": {


### PR DESCRIPTION
Replaces #32

I decided basing it on [vitalets/tizen-webos-sdk](https://github.com/vitalets/docker-tizen-webos-sdk) rather than [persiktv/ubuntu-webos-sdk](https://hub.docker.com/r/persiktv/ubuntu-webos-sdk), because of it being more up to date.

I have verified that the SDK zip in the repo is indeed the exact file contained in the latest LG webOS SDK release.
I also stripped out the tizen tools, as they represented the majority of the image size (but it should otherwise be a plain drop-in of upstream). My changes can be seen here: https://github.com/oddstr13/docker-tizen-webos-sdk/tree/webos-only


Could probably do with some tweaking of the push trigger.

TODO:
- [ ] Set app (and service) version to match git tag.
      Set the version to 0.0.0 for dev builds, and inject the proper version at release time,
      or add CI for bumping the version as a release prepp.


PS:
If I read LGs SDK license right, it allows making a limited number of copies, but also does not allow transferring the license rights, so the docker image is a legal grey area, *potentially* subject to a DMCA in the future, if LG decide they don't want any part in having build testing easily automated. I don't see a way around this, short of completely re-implementing the packaging tooling [which I did make an attempt at last fall](https://github.com/oddstr13/webos-ipk), but alas that implementation is not fully complete, and lacks at a very least the bits that make services work (that, or receiving an explicit license from LG to redistribute the SDK in docker form).
This repo, however is clear of any licensing issues that may or may not arise for the SDK tooling, as none of it is included here.