### PR TITLE
Set rootRequired to false

### DIFF
--- a/tools/gen-manifest.js
+++ b/tools/gen-manifest.js
@@ -18,7 +18,7 @@ fs.writeFileSync(
     appDescription: appinfo.appDescription,
     iconUri: 'https://github.com/jellyfin/jellyfin-webos/raw/master/org.jellyfin.webos/submission-icon.png',
     sourceUrl: 'https://github.com/jellyfin/jellyfin-webos',
-    rootRequired: true,
+    rootRequired: false,
     ipkUrl: ipkfile,
     ipkHash: {
       sha256: ipkhash,


### PR DESCRIPTION
Root is not required to run jellyfin. I noticed this field in webosbrew manifest so for subsequent builds it will not declare to require root.