### PR TITLE
Relax URL validation

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -175,7 +175,7 @@ function Init() {
 }
 // Just ensure that the string has no spaces, and begins with either http:// or https:// (case insensitively), and isn't empty after the ://
 function validURL(str) {
-    pattern = /^(http|https):\/\/[^ ]+$/i;
+    pattern = /^https?:\/\/\S+$/i;
     return !!pattern.test(str);
 }
 

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -173,9 +173,9 @@ function Init() {
         }
     }
 }
-// Sourced from jQuery Validation
+// Just ensure that the string has no spaces, and begins with either http:// or https:// (case insensitively), and isn't empty after the ://
 function validURL(str) {
-    pattern = /^(https?):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
+    pattern = /^(http|https):\/\/[^ ]+$/i;
     return !!pattern.test(str);
 }
 


### PR DESCRIPTION
Relaxes the URL validation to just ensure it begins with http:// or https:// (ignoring case), and that it has at least 1 character after that, with no spaces.  This is mostly in line with the discussion of the short term fix for #21 

Note that since this currently only runs on the output of normalizeUrl, it will be guaranteed to start with either https:// or http://, which is why I left that validation in there anyway.

Also note, I don't have the ability to run this locally, but since it's just replacing the regex, I felt it was worth dry-coding it using an online javascript regex tester to make sure I didn't typo anything.  Would definitely want someone to test/validate before merging.

Addresses #21 