### PR TITLE
Add AppHost.screen and supported codecs

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -16,6 +16,11 @@ var appInfo = {
     appVersion: '0.0.0'
 };
 
+var deviceInfo;
+webOS.deviceInfo(function (info) {
+    deviceInfo = info;
+});
+
 //Adds .includes to string to do substring matching
 if (!String.prototype.includes) {
   String.prototype.includes = function(search, start) {
@@ -412,6 +417,7 @@ function handoff(url, bundle) {
         contentFrame.removeEventListener('load', onLoad);
 
         injectScriptText(contentFrame.contentDocument, 'window.AppInfo = ' + JSON.stringify(appInfo) + ';');
+        injectScriptText(contentFrame.contentDocument, 'window.DeviceInfo = ' + JSON.stringify(deviceInfo) + ';');
 
         if (bundle.js) {
             injectScriptText(contentFrame.contentDocument, bundle.js);

--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -73,7 +73,14 @@
 
             getDeviceProfile: function (profileBuilder) {
                 postMessage('AppHost.getDeviceProfile');
-                return profileBuilder({ enableMkvProgressive: false, enableSsaRender: true });
+                return profileBuilder({
+                    enableMkvProgressive: false,
+                    enableSsaRender: true,
+                    supportsDolbyAtmos: deviceInfo ? deviceInfo.dolbyAtmos : null,
+                    supportsDolbyVision: deviceInfo ? deviceInfo.dolbyVision : null,
+                    supportsHdr10: deviceInfo ? deviceInfo.hdr10 : null,
+                    supportsTrueHd: deviceInfo ? deviceInfo.dolbyAtmos : null
+                });
             },
 
             getSyncProfile: function (profileBuilder) {

--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -5,7 +5,7 @@
  *
 */
 
-(function(AppInfo) {
+(function(AppInfo, deviceInfo) {
     'use strict';
 
     console.log('WebOS adapter');
@@ -127,4 +127,4 @@
             postMessage('hideMediaSession');
         }
     };
-})(window.AppInfo);
+})(window.AppInfo, window.DeviceInfo);

--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -88,6 +88,13 @@
                     isSupported: isSupported
                 });
                 return isSupported;
+            },
+
+            screen: function () {
+                return deviceInfo ? {
+                    width: deviceInfo.screenWidth,
+                    height: deviceInfo.screenHeight
+                } : null;
             }
         },
 


### PR DESCRIPTION
**Changes**
- Add `AppHost.screen` function.
To limit transcoding profiles with maximum resolution: https://github.com/jellyfin/jellyfin-web/pull/3343
- Expose supported codecs.
_Only `supportsTrueHd` is currently in use._

:warning: Need to test screen on 4K TV:
1. Go to `Settings / Playback`.
2. Open select `Home quality`.
3. You should see 4K options.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/59