### PR TITLE
Adjust screen size for 4K/8K UHD

### DIFF
--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -35,6 +35,23 @@
         'multiserver'
     ];
 
+    if (deviceInfo) {
+        var devicePixelRatio = 1;
+
+        if (deviceInfo.uhd8K){
+            console.log("8K UHD is supported");
+            devicePixelRatio = 4;
+        } else if (deviceInfo.uhd){
+            console.log("4K UHD is supported");
+            devicePixelRatio = 2;
+        } else {
+            console.log("UHD is not supported");
+        }
+
+        deviceInfo.screenWidth = Math.floor(deviceInfo.screenWidth * devicePixelRatio);
+        deviceInfo.screenHeight = Math.floor(deviceInfo.screenHeight * devicePixelRatio);
+    }
+
     window.NativeShell = {
         AppHost: {
             init: function () {


### PR DESCRIPTION
#79 may return FHD (`screenWidth` and `screenHeight`) on 4K and 8K UHD.
Tested on webOS 1.2 and webOS 5.0 emulators, but still need to test on a real TV.