### PR TITLE
Remove interpretation of Dolby Atmos as supporting TrueHD

### DIFF
--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -78,8 +78,7 @@
                     enableSsaRender: true,
                     supportsDolbyAtmos: deviceInfo ? deviceInfo.dolbyAtmos : null,
                     supportsDolbyVision: deviceInfo ? deviceInfo.dolbyVision : null,
-                    supportsHdr10: deviceInfo ? deviceInfo.hdr10 : null,
-                    supportsTrueHd: deviceInfo ? deviceInfo.dolbyAtmos : null
+                    supportsHdr10: deviceInfo ? deviceInfo.hdr10 : null
                 });
             },
 


### PR DESCRIPTION
Was introduced in #79

**Issues**
Fixes #111
Fixes #118
Fixes #129 (https://github.com/jellyfin/jellyfin-webos/issues/129#issuecomment-1346781178)
Fixes https://github.com/jellyfin/jellyfin-web/issues/4237

We need someone to recheck #59. But this may be due to a transcoding problem (https://github.com/jellyfin/jellyfin/pull/9016#issue-1521365292).