### PR TITLE
Add support for deep-link navigation via launch parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ All Jellyfin webOS code is licensed under the MPL 2.0 license, some parts incorp
 
 ---
 
+## Deeplinks
+App supports opening specific URL when opening via Luna API, for example:
+```sh
+luna-send -n 1 luna://com.webos.applicationManager/launch '{"id":"org.jellyfin.webos","params":{"url":
+"/details?id=<CONTENT_ID>&serverId=<SERVER_ID>"}}'
+```
+
 ## Development
 
 The general development workflow looks like this:

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -21,6 +21,20 @@ webOS.deviceInfo(function (info) {
     deviceInfo = info;
 });
 
+
+var launchParams;
+document.addEventListener("webOSLaunch", function (data) {
+    launchParams = data.detail;
+    console.log("Launch: " + JSON.stringify(data.detail));
+});
+document.addEventListener("webOSRelaunch", function (data) {
+    launchParams = data.detail;
+    console.log("Relaunch: " + JSON.stringify(data.detail));
+    if(launchParams.url){
+        Init() // reinit if relaunched with arguments
+    }
+});
+
 //Adds .includes to string to do substring matching
 if (!String.prototype.includes) {
   String.prototype.includes = function(search, start) {
@@ -330,6 +344,11 @@ function handleSuccessManifest(data, baseurl) {
     } else {
         var hosturl = normalizeUrl(baseurl + "/web/" + data.start_url);
     }
+    if (launchParams.url) {
+        const start_url = hosturl.split("#", 1);
+        hosturl = start_url + "#" + launchParams.url;
+    }
+
 
     curr_req = false;
 


### PR DESCRIPTION
While developing a custom webOS launcher, I discovered that the Jellyfin webOS client cannot be opened directly on a specific item (e.g., a movie or episode) using launch parameters.
To enable deep-linking from the launcher, I added support for reading launch parameters and navigating to the corresponding url on startup.

**Notes**
- This change does not affect the standard startup flow.
- Tested on real webOS device (rooted webOS 24) with Jellyfin Server 10.10.7.