### PR TITLE
Fix login screen when multiple servers have been previously stored

### DIFF
--- a/frontend/appinfo.json
+++ b/frontend/appinfo.json
@@ -5,7 +5,7 @@
     "bgImage": "assets/splash.png",
     "title": "Jellyfin",
     "type": "web",
-    "version": "1.2.3",
+    "version": "1.2.2",
     "splashBackground": "assets/splash.png",
     "bgColor": "#000b25",
     "vendor": "Jellyfin Project",

--- a/frontend/appinfo.json
+++ b/frontend/appinfo.json
@@ -5,7 +5,7 @@
     "bgImage": "assets/splash.png",
     "title": "Jellyfin",
     "type": "web",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "splashBackground": "assets/splash.png",
     "bgColor": "#000b25",
     "vendor": "Jellyfin Project",

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -166,6 +166,8 @@ function Init() {
 
     if (storage.exists('connected_servers')) {
         connected_servers = storage.get('connected_servers')
+        renderServerList(connected_servers);
+
         var first_server = connected_servers[Object.keys(connected_servers)[0]]
         document.querySelector('#baseurl').value = first_server.baseurl;
         document.querySelector('#auto_connect').checked = first_server.auto_connect;
@@ -177,7 +179,7 @@ function Init() {
                 handleServerSelect();
             }
         }
-        renderServerList(connected_servers);
+        
     }
 }
 // Just ensure that the string has no spaces, and begins with either http:// or https:// (case insensitively), and isn't empty after the ://
@@ -294,7 +296,7 @@ function handleSuccessServerInfo(data, baseurl, auto_connect) {
                 displayError("The server ID has changed since the last connection, please check if you are reaching your own server. To connect anyway, click connect again.");
                 delete connected_servers[server_id]
                 connected_servers[data.Id] = ({ 'baseurl': baseurl, 'auto_connect': false, 'id': false })
-                storage.set('connected_server', connected_servers)
+                storage.set('connected_servers', connected_servers)
                 return false
             }
         }
@@ -325,13 +327,17 @@ function lruStrategy(old_items,max_items,new_item) {
 }
 
 function handleSuccessManifest(data, baseurl) {
+    var hosturl;
     if(data.start_url.includes("/web")){
-        var hosturl = normalizeUrl(baseurl + "/" + data.start_url);
+        hosturl = normalizeUrl(baseurl + "/" + data.start_url);
     } else {
-        var hosturl = normalizeUrl(baseurl + "/web/" + data.start_url);
+        hosturl = normalizeUrl(baseurl + "/web/" + data.start_url);
     }
 
     curr_req = false;
+
+    // Ensure we work against the persisted server list.
+    connected_servers = getConnectedServers();
 
     for (var server_id in connected_servers) {
         var info = connected_servers[server_id]
@@ -355,16 +361,29 @@ function handleSuccessManifest(data, baseurl) {
             return;
         }
     }
-    //no id, unshoft generates unique(?) index
-    connected_servers.unshift({
+
+    // Fallback: if the server wasn't in the list (unexpected), add it keyed by URL.
+    // (We don't have a stable server Id from manifest.json alone.)
+    var fallback_key = 'url:' + baseurl;
+    connected_servers[fallback_key] = ({
         'baseurl': baseurl,
         'hosturl': hosturl,
-        'Name': data.shortname,
-        'Address': new URL(baseurl).hostname.slice(0,8),
-    })
-    storage.set('connected_server', servers)
-    console.log("martin:handleSuccessManifest added server");
-    console.log(info);
+        'auto_connect': false,
+        'id': false,
+        'Name': data.shortname || baseurl,
+        'Address': baseurl
+    });
+    storage.set('connected_servers', connected_servers);
+
+    // Continue with normal flow.
+    getTextToInject(function (bundle) {
+        handoff(hosturl, bundle);
+    }, function (error) {
+        console.error(error);
+        displayError(error);
+        hideConnecting();
+        curr_req = false;
+    });
 }
 
 function handleAbort() {
@@ -389,7 +408,6 @@ function handleFailure(data) {
     }
 
     hideConnecting();
-    storage.remove('connected_server');
     curr_req = false;
 }
 

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -164,9 +164,8 @@ function Init() {
 
     navigationInit();
 
-    if (storage.exists('connected_servers')) {
-        var connected_servers = storage.get('connected_servers');
-
+    var connected_servers = getConnectedServers();
+    if (Object.keys(connected_servers).length > 0) {
         var first_server = connected_servers[Object.keys(connected_servers)[0]]
         document.querySelector('#baseurl').value = first_server.baseurl;
         document.querySelector('#auto_connect').checked = first_server.auto_connect;
@@ -274,11 +273,11 @@ function getManifest(baseurl) {
 }
 
 function getConnectedServers() {
-    var connected_servers = storage.get('connected_servers');
-    if (!connected_servers) {
-        connected_servers = {};
-    }
-    return connected_servers;
+    return storage.get('connected_servers') || {};
+}
+
+function setConnectedServers(servers) {
+    storage.set('connected_servers', servers);
 }
 
 
@@ -295,7 +294,7 @@ function handleSuccessServerInfo(data, baseurl, auto_connect) {
                 displayError("The server ID has changed since the last connection, please check if you are reaching your own server. To connect anyway, click connect again.");
                 delete connected_servers[server_id]
                 connected_servers[data.Id] = ({ 'baseurl': baseurl, 'auto_connect': false, 'id': false })
-                storage.set('connected_servers', connected_servers)
+                setConnectedServers(connected_servers)
                 return false
             }
         }
@@ -304,7 +303,7 @@ function handleSuccessServerInfo(data, baseurl, auto_connect) {
 
     connected_servers = lruStrategy(connected_servers,4, { 'baseurl': baseurl, 'auto_connect': auto_connect, 'id': data.Id, 'Name':data.ServerName })
 
-    storage.set('connected_servers', connected_servers);
+    setConnectedServers(connected_servers);
 
 
     getManifest(baseurl)
@@ -343,7 +342,7 @@ function handleSuccessManifest(data, baseurl) {
             info['hosturl'] = hosturl
             info['Address'] = info['Address'] || baseurl
 
-            storage.set('connected_servers', connected_servers)
+            setConnectedServers(connected_servers)
             console.log("martin:handleSuccessManifest modified server");
             console.log(info);
 
@@ -371,7 +370,7 @@ function handleSuccessManifest(data, baseurl) {
         'Name': data.shortname || baseurl,
         'Address': baseurl
     });
-    storage.set('connected_servers', connected_servers);
+    setConnectedServers(connected_servers);
 
     // Continue with normal flow.
     getTextToInject(function (bundle) {

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -165,8 +165,8 @@ function Init() {
     navigationInit();
 
     var connected_servers = getConnectedServers();
-    if (Object.keys(connected_servers).length > 0) {
-        var first_server = connected_servers[Object.keys(connected_servers)[0]]
+    var [first_server] = Object.values(connected_servers);
+    if (first_server) {
         document.querySelector('#baseurl').value = first_server.baseurl;
         document.querySelector('#auto_connect').checked = first_server.auto_connect;
         if (window.performance && window.performance.navigation.type == window.performance.navigation.TYPE_BACK_FORWARD) {

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -165,8 +165,7 @@ function Init() {
     navigationInit();
 
     if (storage.exists('connected_servers')) {
-        connected_servers = storage.get('connected_servers')
-        renderServerList(connected_servers);
+        var connected_servers = storage.get('connected_servers');
 
         var first_server = connected_servers[Object.keys(connected_servers)[0]]
         document.querySelector('#baseurl').value = first_server.baseurl;
@@ -179,7 +178,7 @@ function Init() {
                 handleServerSelect();
             }
         }
-        
+        renderServerList(connected_servers);
     }
 }
 // Just ensure that the string has no spaces, and begins with either http:// or https:// (case insensitively), and isn't empty after the ://
@@ -275,7 +274,7 @@ function getManifest(baseurl) {
 }
 
 function getConnectedServers() {
-    connected_servers = storage.get('connected_servers');
+    var connected_servers = storage.get('connected_servers');
     if (!connected_servers) {
         connected_servers = {};
     }
@@ -286,7 +285,7 @@ function getConnectedServers() {
 function handleSuccessServerInfo(data, baseurl, auto_connect) {
     curr_req = false;
 
-    connected_servers = getConnectedServers();
+    var connected_servers = getConnectedServers();
     for (var server_id in connected_servers) {
         var server = connected_servers[server_id]
         if (server.baseurl == baseurl) {
@@ -336,8 +335,7 @@ function handleSuccessManifest(data, baseurl) {
 
     curr_req = false;
 
-    // Ensure we work against the persisted server list.
-    connected_servers = getConnectedServers();
+    var connected_servers = getConnectedServers();
 
     for (var server_id in connected_servers) {
         var info = connected_servers[server_id]
@@ -550,7 +548,6 @@ window.addEventListener('message', function (msg) {
 /* Server auto-discovery */
 
 var discovered_servers = {};
-var connected_servers = {};
 
 function renderServerList(server_list) {
     for (var server_id in server_list) {


### PR DESCRIPTION
The existing code was using a mix of `'connected_servers'` and `'connected_server'`, causing pre-stored servers to never actually show up on the login page.