### PR TITLE
Fix deviceInfo race condition causing inconsistent DoVi detection

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -17,22 +17,20 @@ var appInfo = {
 };
 
 var deviceInfo;
-var deviceInfoCallbacks = [];
-var deviceInfoReady = false;
+var deviceInfoCallback;
 webOS.deviceInfo(function (info) {
     deviceInfo = info;
-    deviceInfoReady = true;
-    for (var i = 0; i < deviceInfoCallbacks.length; i++) {
-        deviceInfoCallbacks[i](info);
+    if (deviceInfoCallback) {
+        deviceInfoCallback(info);
+        deviceInfoCallback = null;
     }
-    deviceInfoCallbacks = [];
 });
 
 function waitForDeviceInfo(callback) {
-    if (deviceInfoReady) {
+    if (deviceInfo) {
         callback(deviceInfo);
     } else {
-        deviceInfoCallbacks.push(callback);
+        deviceInfoCallback = callback;
     }
 }
 
@@ -484,21 +482,16 @@ function handoff(url, bundle) {
         contentFrame.contentDocument.removeEventListener('DOMContentLoaded', onLoad);
         contentFrame.removeEventListener('load', onLoad);
 
-        // Wait for deviceInfo from the Luna service before injecting into the iframe.
-        // Without this, deviceInfo may be undefined if the async callback hasn't fired yet,
-        // causing the device profile to miss DoVi/HDR10 capabilities (race condition).
-        waitForDeviceInfo(function () {
-            injectScriptText(contentFrame.contentDocument, 'window.AppInfo = ' + JSON.stringify(appInfo) + ';');
-            injectScriptText(contentFrame.contentDocument, 'window.DeviceInfo = ' + JSON.stringify(deviceInfo) + ';');
+        injectScriptText(contentFrame.contentDocument, 'window.AppInfo = ' + JSON.stringify(appInfo) + ';');
+        injectScriptText(contentFrame.contentDocument, 'window.DeviceInfo = ' + JSON.stringify(deviceInfo) + ';');
 
-            if (bundle.js) {
-                injectScriptText(contentFrame.contentDocument, bundle.js);
-            }
+        if (bundle.js) {
+            injectScriptText(contentFrame.contentDocument, bundle.js);
+        }
 
-            if (bundle.css) {
-                injectStyleText(contentFrame.contentDocument, bundle.css);
-            }
-        });
+        if (bundle.css) {
+            injectStyleText(contentFrame.contentDocument, bundle.css);
+        }
     }
 
     function onUnload() {
@@ -526,8 +519,12 @@ function handoff(url, bundle) {
     // In the case of "loading" and "interactive" are not caught
     contentFrame.addEventListener('load', onLoad);
 
-    contentFrame.style.display = '';
-    contentFrame.src = url;
+    // Ensure deviceInfo is available before loading the iframe.
+    // webOS.deviceInfo() is an async Luna service call that may not have completed yet.
+    waitForDeviceInfo(function () {
+        contentFrame.style.display = '';
+        contentFrame.src = url;
+    });
 }
 
 window.addEventListener('message', function (msg) {

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -17,9 +17,24 @@ var appInfo = {
 };
 
 var deviceInfo;
+var deviceInfoCallbacks = [];
+var deviceInfoReady = false;
 webOS.deviceInfo(function (info) {
     deviceInfo = info;
+    deviceInfoReady = true;
+    for (var i = 0; i < deviceInfoCallbacks.length; i++) {
+        deviceInfoCallbacks[i](info);
+    }
+    deviceInfoCallbacks = [];
 });
+
+function waitForDeviceInfo(callback) {
+    if (deviceInfoReady) {
+        callback(deviceInfo);
+    } else {
+        deviceInfoCallbacks.push(callback);
+    }
+}
 
 //Adds .includes to string to do substring matching
 if (!String.prototype.includes) {
@@ -469,16 +484,21 @@ function handoff(url, bundle) {
         contentFrame.contentDocument.removeEventListener('DOMContentLoaded', onLoad);
         contentFrame.removeEventListener('load', onLoad);
 
-        injectScriptText(contentFrame.contentDocument, 'window.AppInfo = ' + JSON.stringify(appInfo) + ';');
-        injectScriptText(contentFrame.contentDocument, 'window.DeviceInfo = ' + JSON.stringify(deviceInfo) + ';');
+        // Wait for deviceInfo from the Luna service before injecting into the iframe.
+        // Without this, deviceInfo may be undefined if the async callback hasn't fired yet,
+        // causing the device profile to miss DoVi/HDR10 capabilities (race condition).
+        waitForDeviceInfo(function () {
+            injectScriptText(contentFrame.contentDocument, 'window.AppInfo = ' + JSON.stringify(appInfo) + ';');
+            injectScriptText(contentFrame.contentDocument, 'window.DeviceInfo = ' + JSON.stringify(deviceInfo) + ';');
 
-        if (bundle.js) {
-            injectScriptText(contentFrame.contentDocument, bundle.js);
-        }
+            if (bundle.js) {
+                injectScriptText(contentFrame.contentDocument, bundle.js);
+            }
 
-        if (bundle.css) {
-            injectStyleText(contentFrame.contentDocument, bundle.css);
-        }
+            if (bundle.css) {
+                injectStyleText(contentFrame.contentDocument, bundle.css);
+            }
+        });
     }
 
     function onUnload() {


### PR DESCRIPTION
`webOS.deviceInfo()` is an async Luna service call, but the `onLoad` handler in `handoff()` serializes `window.DeviceInfo` immediately. If the Luna callback hasn't fired yet, `deviceInfo` is `undefined` and the profile builder gets `null` for `supportsDolbyVision` / `supportsHdr10`, constructing a profile that misses HDR capabilities.

This causes the same DoVi file to sometimes trigger Dolby Vision correctly and sometimes fall back to SDR or force a full transcode depending on startup timing.

Uses a callback queue (no Promises — unreliable on older webOS) to ensure device capabilities are known before injecting into the iframe.

Addresses jellyfin/jellyfin#16092, jellyfin/jellyfin#16179