### PR TITLE
Focus content frame to provide navigation when internal focus is missing

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -508,6 +508,7 @@ function handoff(url, bundle) {
 
     contentFrame.style.display = '';
     contentFrame.src = url;
+    contentFrame.focus();
 }
 
 window.addEventListener('message', function (msg) {


### PR DESCRIPTION
This is not a fix, but a workaround - it allows you to refocus using the arrow keys.

**Changes**
Focus the content frame to provide navigation when internal focus is missing.

**Issues**
https://github.com/jellyfin/jellyfin-webos/issues/313