### PR TITLE
Replace deprecated Buffer constructor in discovery service

### DIFF
--- a/services/service.js
+++ b/services/service.js
@@ -76,7 +76,7 @@ function handleDiscoveryResponse(message, remote) {
 }
 
 function sendJellyfinDiscovery() {
-	var msg = new Buffer(JELLYFIN_DISCOVERY_MESSAGE);
+	var msg = Buffer.from(JELLYFIN_DISCOVERY_MESSAGE);
 	client4.send(msg, 0, msg.length, 7359, "255.255.255.255");
 
 	// if (client6) {


### PR DESCRIPTION
## Summary
- Replace `new Buffer()` with `Buffer.from()` in the UDP discovery service
- `new Buffer()` has been deprecated since Node.js v6 ([DEP0005](https://nodejs.org/api/deprecations.html#dep0005-buffer-constructor)) due to security and usability concerns
- `Buffer.from()` has been available since Node.js v5.10.0

## Test plan
- [ ] Verify server autodiscovery still works on webOS devices