### PR TITLE
fix: infer HDR capabilities from display type on older webOS TVs

### DIFF
--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -5,10 +5,22 @@
  *
 */
 
-(function(AppInfo, deviceInfo) {
+(function(AppInfo, rawDeviceInfo) {
     'use strict';
 
     console.log('WebOS adapter');
+
+    var deviceInfo = rawDeviceInfo ? Object.assign({}, rawDeviceInfo) : {};
+
+    if (!deviceInfo.hdr10 && deviceInfo.oled) {
+        console.debug('WebOS adapter: inferring HDR10 support from OLED display');
+        deviceInfo.hdr10 = true;
+    }
+
+    if (!deviceInfo.dolbyVision && deviceInfo.oled) {
+        console.debug('WebOS adapter: inferring Dolby Vision support from OLED display');
+        deviceInfo.dolbyVision = true;
+    }
 
     function postMessage(type, data) {
         window.top.postMessage({
@@ -76,9 +88,9 @@
                 return profileBuilder({
                     enableMkvProgressive: false,
                     enableSsaRender: true,
-                    supportsDolbyAtmos: deviceInfo ? deviceInfo.dolbyAtmos : null,
-                    supportsDolbyVision: deviceInfo ? deviceInfo.dolbyVision : null,
-                    supportsHdr10: deviceInfo ? deviceInfo.hdr10 : null
+                    supportsDolbyAtmos: deviceInfo.dolbyAtmos ?? null,
+                    supportsDolbyVision: deviceInfo.dolbyVision ?? null,
+                    supportsHdr10: deviceInfo.hdr10 ?? null
                 });
             },
 
@@ -97,10 +109,13 @@
             },
 
             screen: function () {
-                return deviceInfo ? {
-                    width: deviceInfo.screenWidth,
-                    height: deviceInfo.screenHeight
-                } : null;
+                if (deviceInfo.screenWidth && deviceInfo.screenHeight) {
+                    return {
+                        width: deviceInfo.screenWidth,
+                        height: deviceInfo.screenHeight
+                    };
+                }
+                return null;
             }
         },
 


### PR DESCRIPTION
## Problem

On older LG TVs (2016-2017 models like C6, B7, UJ series), the LG SDK's `getConfigs` API may report HDR10 and Dolby Vision as unsupported even when the hardware supports them. This causes the device profile sent to the Jellyfin server to not advertise HDR support, resulting in unnecessary SDR transcoding of HDR content.

As noted in [#278](https://github.com/jellyfin/jellyfin-webos/issues/278), users can verify that HDR content plays fine by disabling video transcoding for their user, confirming the issue is with capability detection, not actual playback support.

## Changes

**`frontend/js/index.js`** - Race condition fix:
- Added `onDeviceInfoReady()` callback mechanism to ensure `webOS.deviceInfo()` async callback completes before building the device profile
- Added safety check for `webOS.deviceInfo` availability (may not exist on very old webOS versions)

**`frontend/js/webOS.js`** - HDR fallback detection:
- If the SDK reports `hdr10: false` but the TV is OLED or UHD, infer HDR10 support (all LG OLED TVs support HDR10, most UHD TVs from 2016+ do too)
- If the SDK reports `dolbyVision: false` but the TV is OLED, infer Dolby Vision support (all LG OLED TVs support DV)
- Normalized `deviceInfo` to always be an object, simplifying null checks

## Testing

This fix relies on the fact that:
- All LG OLED TVs support HDR10 and Dolby Vision
- Most UHD LG TVs from 2016+ support HDR10
- The `deviceInfo.oled` and `deviceInfo.uhd` properties are correctly reported by the LG SDK even when `tv.model.supportHDR` returns incorrect values

Fixes #278