### PR TITLE
Fix missing playback/action buttons on webOS 5 (Chromium 68)

### DIFF
--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -10,6 +10,93 @@
 
     console.log('WebOS adapter');
 
+    // --- webOS 5 (Chromium 68) Intl time-zone shim ---
+    // On webOS 5 the browser's ICU cannot resolve the default host time zone,
+    // so any localized date/time call (Date.toLocale* / Intl.DateTimeFormat with
+    // no explicit timeZone) throws:
+    //   RangeError: Unsupported time zone specified undefined
+    // That exception aborts jellyfin-web's item-detail render (getDisplayTime),
+    // which is why playback/action buttons never appear. The OS UTC offset and
+    // an explicit timeZone:'UTC' both work, so we render correct *local* time by
+    // shifting the timestamp into UTC. The shim only activates when the default
+    // zone is actually broken, so it is a no-op on normal browsers.
+    (function () {
+        var defaultTZBroken = false;
+        try {
+            new Date().toLocaleTimeString('en-US', { hour: 'numeric' });
+        } catch (e) {
+            defaultTZBroken = true;
+        }
+        if (!defaultTZBroken) {
+            return;
+        }
+        console.log('WebOS adapter: applying Intl time-zone shim (host tz unresolved)');
+
+        function assign(target, src) {
+            if (src) {
+                for (var k in src) {
+                    if (Object.prototype.hasOwnProperty.call(src, k)) {
+                        target[k] = src[k];
+                    }
+                }
+            }
+            return target;
+        }
+        // Returns a Date whose UTC fields equal this date's local wall-clock time,
+        // so formatting it as UTC yields the correct local time string.
+        function toWallClockUTC(d) {
+            return new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+        }
+        function withUTC(options) {
+            return assign(assign({}, options), { timeZone: 'UTC' });
+        }
+        function hasTZ(options) {
+            return options != null && options.timeZone != null;
+        }
+
+        function patchDateMethod(name) {
+            var orig = Date.prototype[name];
+            Date.prototype[name] = function (locales, options) {
+                if (hasTZ(options)) {
+                    return orig.call(this, locales, options);
+                }
+                return orig.call(toWallClockUTC(this), locales, withUTC(options));
+            };
+        }
+        patchDateMethod('toLocaleTimeString');
+        patchDateMethod('toLocaleDateString');
+        patchDateMethod('toLocaleString');
+
+        if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
+            var OrigDTF = Intl.DateTimeFormat;
+            var Patched = function DateTimeFormat(locales, options) {
+                if (hasTZ(options)) {
+                    return new OrigDTF(locales, options);
+                }
+                var f = new OrigDTF(locales, withUTC(options));
+                var toDate = function (d) {
+                    if (d == null) {
+                        d = new Date();
+                    } else if (!(d instanceof Date)) {
+                        d = new Date(d);
+                    }
+                    return toWallClockUTC(d);
+                };
+                return {
+                    format: function (d) { return f.format(toDate(d)); },
+                    formatToParts: function (d) { return f.formatToParts(toDate(d)); },
+                    resolvedOptions: function () { return f.resolvedOptions(); }
+                };
+            };
+            Patched.prototype = OrigDTF.prototype;
+            Patched.supportedLocalesOf = function (locales, options) {
+                return OrigDTF.supportedLocalesOf(locales, options);
+            };
+            Intl.DateTimeFormat = Patched;
+        }
+    })();
+    // --- END time-zone shim ---
+
     function postMessage(type, data) {
         window.top.postMessage({
             type: type,


### PR DESCRIPTION
## Problem

On webOS 5 devices (e.g. LG NANO91 series, Chromium 68), the item detail
page shows **no action buttons** — Play, Restart, Mark-played, Favorite,
More are all missing. Playback is only possible from "Continue Watching"
(which resumes directly and bypasses the detail page). The app otherwise
works.

## Root cause

webOS 5's browser cannot resolve the **default host time zone** via ICU.
Any localized date/time call with no explicit `timeZone` throws:

```
RangeError: Unsupported time zone specified undefined
    at new DateTimeFormat (native)
    at Date.toLocaleTimeString (native)
    at ... getDisplayTime (jellyfin-web datetime helper)
    at ... item detail render
```

jellyfin-web calls `getDisplayTime` on every item-detail render (the
"Ends at …" line). The uncaught exception aborts the detail-header
render — the same code path that un-hides the action buttons — so they
silently never appear. It throws on essentially every render (~1000×
while browsing).

Verified on a **55NANO916NA, webOS 5.6.2, Chrome 68.0.3440.106** via
remote inspector (CDP):

| Probe | Result |
|---|---|
| `new Date().getTimezoneOffset()` | `-120` (offset works) |
| `Intl.DateTimeFormat().resolvedOptions().timeZone` | **throws** "Unsupported time zone specified undefined" |
| `toLocaleTimeString(locale, {hour,minute})` | **throws** (same) |
| `…{timeZone:'UTC'}` | works |
| `…{timeZone:'Etc/GMT-2'}` | throws — ICU wants `Area/Location`, rejects `Etc/GMT` |

## Fix

A small Intl time-zone shim in the injected adapter (`frontend/js/webOS.js`).
The OS UTC **offset** works and `timeZone:'UTC'` works, so it renders
correct **local** time by shifting the timestamp into UTC — no IANA zone
name required. It patches `Date.prototype.toLocale{Time,Date,}String` and
wraps `Intl.DateTimeFormat`.

The shim **only activates when the default zone is actually broken**
(detected once at startup), so it is a complete no-op on unaffected
browsers.

## Testing

Built and installed on the affected TV via `ares-install`, attached the
remote inspector, and reproduced the missing buttons. After the shim:
buttons render correctly and the exception count drops from ~1000 → **0**.
Times display correctly in local time.

## Caveat

Direct `Intl.DateTimeFormat` consumers will see
`resolvedOptions().timeZone === 'UTC'` on affected devices, though
formatted times remain correct via the UTC shift.