### PR TITLE
fix: allow Dolby Vision in MKV on webOS 25+, plus connect-screen bug fixes

### DIFF
--- a/frontend/js/ajax.js
+++ b/frontend/js/ajax.js
@@ -66,18 +66,17 @@ AJAX.prototype.request = function(url, settings) {
 		if (xhr.readyState == XMLHttpRequest.DONE) {
 			if (xhr.status == 200) {
                 if (settings.success) {
+					var parsedResponse;
 					try {
-                    	settings.success(JSON.parse(xhr.responseText));
+						parsedResponse = JSON.parse(xhr.responseText);
 					} catch (error) {
 						console.error(error);
-						if (error instanceof SyntaxError) {
-							if (settings.error) {
-								settings.error({error: "The server did not return valid JSON data."});
-							}
-						} else if (settings.error) {
-							settings.error({error: 0});
+						if (settings.error) {
+							settings.error({error: "The server did not return valid JSON data."});
 						}
+						return;
 					}
+					settings.success(parsedResponse);
                 }
             } else if (xhr.status == 204) {
                 if (settings.success) {                

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -43,7 +43,7 @@ function findIndex(array, currentNode) {
     //This just implements the following function which is not available on some LG TVs
     //Array.from(allElements).findIndex(function (el) { return currentNode.isEqualNode(el); })
     for (var i = 0, item; item = array[i]; i++) {
-        if (currentNode.isEqualNode(item))
+        if (item === currentNode)
             return i;
     }
 }
@@ -187,7 +187,7 @@ function validURL(str) {
 }
 
 function normalizeUrl(url) {
-    url = url.trimLeft ? url.trimLeft() : url.trimStart();
+    url = url.trim ? url.trim() : url;
     if (url.indexOf("http://") != 0 && url.indexOf("https://") != 0) {
         // assume http
         url = "http://" + url;
@@ -294,7 +294,7 @@ function handleSuccessServerInfo(data, baseurl, auto_connect) {
                 displayError("The server ID has changed since the last connection, please check if you are reaching your own server. To connect anyway, click connect again.");
                 delete connected_servers[server_id]
                 connected_servers[data.Id] = ({ 'baseurl': baseurl, 'auto_connect': false, 'id': false })
-                storage.set('connected_server', connected_servers)
+                storage.set('connected_servers', connected_servers)
                 return false
             }
         }
@@ -317,7 +317,7 @@ function lruStrategy(old_items,max_items,new_item) {
     delete old_items[id] // LRU: re-insert entry (in front) each time it is used
     result[id] =  new_item
     var keys = Object.keys(old_items)
-    for (var i=0; i<max_items-1; i++){
+    for (var i=0; i<max_items-1 && i<keys.length; i++){
         var current_key=keys[i]
         result[current_key] = old_items[current_key]
     }
@@ -325,6 +325,12 @@ function lruStrategy(old_items,max_items,new_item) {
 }
 
 function handleSuccessManifest(data, baseurl) {
+    if (typeof data.start_url !== 'string') {
+        curr_req = false;
+        handleFailure({ error: "The server did not return a usable web manifest. Are you connecting to a Jellyfin Server?" });
+        return;
+    }
+
     if(data.start_url.includes("/web")){
         var hosturl = normalizeUrl(baseurl + "/" + data.start_url);
     } else {
@@ -340,8 +346,6 @@ function handleSuccessManifest(data, baseurl) {
             info['Address'] = info['Address'] || baseurl
 
             storage.set('connected_servers', connected_servers)
-            console.log("martin:handleSuccessManifest modified server");
-            console.log(info);
 
         // avoid Promise as it's buggy in some WebOS
             getTextToInject(function (bundle) {
@@ -355,16 +359,15 @@ function handleSuccessManifest(data, baseurl) {
             return;
         }
     }
-    //no id, unshoft generates unique(?) index
-    connected_servers.unshift({
+    //no matching entry found, add a new one keyed by the baseurl
+    connected_servers[baseurl] = {
         'baseurl': baseurl,
         'hosturl': hosturl,
-        'Name': data.shortname,
-        'Address': new URL(baseurl).hostname.slice(0,8),
-    })
-    storage.set('connected_server', servers)
-    console.log("martin:handleSuccessManifest added server");
-    console.log(info);
+        'Name': data.short_name,
+        'Address': new URL(baseurl).hostname.slice(0,8)
+    };
+    storage.set('connected_servers', connected_servers)
+    console.log("handleSuccessManifest added server");
 }
 
 function handleAbort() {
@@ -389,7 +392,6 @@ function handleFailure(data) {
     }
 
     hideConnecting();
-    storage.remove('connected_server');
     curr_req = false;
 }
 
@@ -543,7 +545,7 @@ function renderServerList(server_list) {
 
 function renderSingleServer(server_id, server) {
     var server_list = document.getElementById("serverlist");
-    var server_card = document.getElementById("server_" + server.Id);
+    var server_card = document.getElementById("server_" + server_id);
 
     if (!server_card) {
         server_card = document.createElement("li");
@@ -599,7 +601,7 @@ function verifyThenAdd(server) {
                 server.system_info_public = data;
                 if (!discovered_servers[server.Id]) {
                     discovered_servers[server.Id] = server;
-                    renderServerList(discovered_servers);
+                    renderSingleServer(server.Id, server);
                 }
             }
             servers_verifying[server.Id] = true;
@@ -630,7 +632,7 @@ function startDiscovery() {
     discover = webOS.service.request("luna://org.jellyfin.webos.service", {
         method: "discover",
         parameters: {
-            uniqueToken: 'fooo'
+            uniqueToken: Date.now().toString(36) + '-' + Math.random().toString(36).slice(2)
         },
         subscribe: true,
         resubscribe: true,

--- a/frontend/js/storage.js
+++ b/frontend/js/storage.js
@@ -34,7 +34,12 @@ STORAGE.prototype.get = function(name, isJSON) {
 	if (localStorage) {
 		if (localStorage.getItem(name)) {
 			if (isJSON) {
-				return JSON.parse(localStorage.getItem(name));
+				try {
+					return JSON.parse(localStorage.getItem(name));
+				} catch (error) {
+					console.error("Failed to parse stored value for '" + name + "':", error);
+					return undefined;
+				}
 			} else {
 				return localStorage.getItem(name);
 			}

--- a/frontend/js/webOS.js
+++ b/frontend/js/webOS.js
@@ -35,6 +35,51 @@
         'multiserver'
     ];
 
+    // jellyfin-web (served by the connected server, not bundled here) excludes
+    // MKV from the Dolby Vision HEVC codec profile on webOS unless it detects
+    // webOS 25+ - support for that was only added upstream in jellyfin-web
+    // PR #7328, which isn't in any stable server release yet. That leaves
+    // DV-in-MKV files being needlessly transcoded on webOS 25 TVs (2025
+    // C/G-series) even though they can direct play them. Patch the returned
+    // profile so those containers aren't excluded, mirroring the upstream fix,
+    // gated to webOS 25+ so older TVs keep the original (safe) restriction.
+    // See https://github.com/jellyfin/jellyfin-web/issues/8165
+    function getWebOSChromeVersion() {
+        var match = navigator.userAgent.match(/Chrome\/(\d+)/i);
+        return match ? parseInt(match[1], 10) : 0;
+    }
+
+    function isWebOS25OrNewer() {
+        return getWebOSChromeVersion() >= 120;
+    }
+
+    function allowDolbyVisionInMkv(profile) {
+        if (!deviceInfo || !deviceInfo.dolbyVision || !isWebOS25OrNewer()) {
+            return;
+        }
+        if (!profile || !Array.isArray(profile.CodecProfiles)) {
+            return;
+        }
+
+        profile.CodecProfiles.forEach(function (codecProfile) {
+            var isHevcVideoProfile = codecProfile.Type === 'Video'
+                && typeof codecProfile.Codec === 'string'
+                && codecProfile.Codec.split(',').indexOf('hevc') !== -1;
+            var isContainerExclusion = typeof codecProfile.Container === 'string'
+                && codecProfile.Container.charAt(0) === '-';
+
+            if (!isHevcVideoProfile || !isContainerExclusion) {
+                return;
+            }
+
+            var excludedContainers = codecProfile.Container.substring(1).split(',');
+            if (excludedContainers.indexOf('mkv') === -1) {
+                excludedContainers.push('mkv');
+                codecProfile.Container = '-' + excludedContainers.join(',');
+            }
+        });
+    }
+
     window.NativeShell = {
         AppHost: {
             init: function () {
@@ -73,13 +118,17 @@
 
             getDeviceProfile: function (profileBuilder) {
                 postMessage('AppHost.getDeviceProfile');
-                return profileBuilder({
+                var profile = profileBuilder({
                     enableMkvProgressive: false,
                     enableSsaRender: true,
                     supportsDolbyAtmos: deviceInfo ? deviceInfo.dolbyAtmos : null,
                     supportsDolbyVision: deviceInfo ? deviceInfo.dolbyVision : null,
                     supportsHdr10: deviceInfo ? deviceInfo.hdr10 : null
                 });
+
+                allowDolbyVisionInMkv(profile);
+
+                return profile;
             },
 
             getSyncProfile: function (profileBuilder) {


### PR DESCRIPTION
## Summary

- Allow Dolby Vision inside MKV containers on webOS 25+ devices, without waiting on a stable server release to include jellyfin/jellyfin-web#7328. Closes/relates to jellyfin/jellyfin-web#8165 (reported on an LG C5; also verified here on a 2025 G5, webOS 25, firmware 33.31.68).
- Fix several latent bugs in the connect screen / saved-server-list flow (storage key typos, a dead code path that would throw if ever reached, a field-name casing bug that broke dedup for saved servers, and an ajax try/catch that was mis-attributing bugs in success callbacks to "invalid server JSON").
- Two small performance fixes: remote-control navigation no longer does a deep `isEqualNode` comparison across every focusable element on each key press (now a plain identity check), and discovering a new server on the network no longer re-renders the entire saved-server list, just the new card.

## Why

`getDeviceProfile` in `webOS.js` is this app's only hook into jellyfin-web's device-capability negotiation. jellyfin-web currently restricts Dolby Vision to `mp4`/`ts` containers on webOS unless it detects webOS 25+, in which case `mkv` is also allowed (jellyfin/jellyfin-web#7328). That fix merged 2026-05-31 and is only in the v12.0 release-candidate line — no stable Jellyfin server ships it yet. Until it does, webOS 25 TVs (2025 C/G-series) needlessly transcode DV-in-MKV files they can actually direct play.

This patches the profile returned by `profileBuilder` to remove `mkv` from that exclusion list, gated on the TV reporting real Dolby Vision support (via the existing `tv.config.supportDolbyHDRContents` luna query, already wired up correctly) and on detecting webOS 25+ via the Chrome engine version in the user agent — the same signal jellyfin-web itself uses. Older TVs are unaffected.

While testing this on real hardware I found and fixed a handful of pre-existing bugs in the connect-screen server list handling (see commit messages for details) and two small perf issues in remote-control navigation and server-discovery rendering.

## Test plan

- [x] Built via `npm run package`, sideloaded on an LG G5 OLED (webOS 25, firmware 33.31.68) via Developer Mode
- [x] Played a Dolby Vision Profile 5 MKV title; confirmed the server dashboard shows Direct Play instead of Transcode
- [x] Verified DV/HDR10/Atmos capability reporting is unaffected on non-DV and pre-webOS-25 code paths (gate is a no-op unless both conditions hold)
- [x] Connected to two separate servers and confirmed both appear as distinct entries in the saved-server list
- [x] Pasted a URL with trailing whitespace and confirmed it connects instead of failing validation
- [x] Forced a failed connection attempt and confirmed the saved server list is unaffected
